### PR TITLE
Fix setting the width for gedit widgets

### DIFF
--- a/R/gedit.R
+++ b/R/gedit.R
@@ -108,7 +108,7 @@ GEdit <- setRefClass("GEdit",
                          ## constructor arguments
                          arg_list <- list(value = text,
                                           enableKeyEvents=TRUE,
-                                          width = ifelse(is.character(width), width, sprintf("%spx", 8*width)),
+                                          width = 8 * width,
                                           fieldLabel=list(...)$label
                                           )
                          ## empty text


### PR DESCRIPTION
According to
http://www.objis.com/formationextjs/lib/extjs-4.0.0/docs/api/Ext.form.field.Text.html
the width should just be a number in pixels.
